### PR TITLE
Fix typo preventing to load services.yml correctly

### DIFF
--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -33,6 +33,6 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface
      */
     public function registerContainerConfiguration(LoaderInterface $loader, array $managerConfig)
     {
-        $loader->load('@HeimrichHannotContaoRequestBundle/Ressources/config/services.yml');
+        $loader->load('@HeimrichHannotContaoRequestBundle/Resources/config/services.yml');
     }
 }


### PR DESCRIPTION
Just a typo: Res**s**ources -> Resources